### PR TITLE
feat: allow multiple tickets in the same commit message

### DIFF
--- a/lib/success.ts
+++ b/lib/success.ts
@@ -12,7 +12,7 @@ export function getTickets(config: PluginConfig, context: GenerateNotesContext):
     patterns = [new RegExp(config.ticketRegex, 'giu')];
   } else {
     patterns = config.ticketPrefixes!
-    .map(prefix => new RegExp(`\\b${escapeRegExp(prefix)}-(\\d+)\\b`, 'giu'));
+        .map(prefix => new RegExp(`\\b${escapeRegExp(prefix)}-(\\d+)\\b`, 'giu'));
   }
 
   const tickets = new Set<string>();
@@ -20,8 +20,10 @@ export function getTickets(config: PluginConfig, context: GenerateNotesContext):
     for (const pattern of patterns) {
       const matches = commit.message.match(pattern);
       if (matches) {
-        tickets.add(matches[0]);
-        context.logger.info(`Found ticket ${matches[0]} in commit: ${commit.commit.short}`);
+        matches.forEach(match => {
+          tickets.add(match);
+          context.logger.info(`Found ticket ${matches} in commit: ${commit.commit.short}`);
+        });
       }
     }
   }

--- a/test/fakedata.ts
+++ b/test/fakedata.ts
@@ -23,7 +23,7 @@ export const commits: Commit[] = [
   'feat: [UH-1258] better logging ',
   'feat: [UH-1258] Implement release creation',
   'fix: [FIX-123] typescript config',
-  'fix: [TEST-123] test commit',
+  'fix: [TEST-123] [TEST-234] test commit',
 ].map(m => ({
   author,
   committer: author,

--- a/test/test.ts
+++ b/test/test.ts
@@ -12,6 +12,14 @@ describe('Success tests', () => {
       expect(getTickets(config, context)).toEqual(['UH-1258'])
     })
 
+    it('should get multiple tickets on the same commit', () => {
+      const config = {
+        ...pluginConfig,
+        ticketPrefixes: ['TEST']
+      } as PluginConfig;
+      expect(getTickets(config, context)).toEqual(['TEST-123', 'TEST-234'])
+    })
+
     it('should analyze tickets with many ticketPrefix', () => {
       const config = {
         ...pluginConfig,
@@ -22,13 +30,13 @@ describe('Success tests', () => {
 
     it('should analyze tickets with ticketRegex', () => {
       const ticketRegex = '[A-Za-z]+-\\d+';
-      
+
       const config: PluginConfig = {
         ...pluginConfig,
         ticketRegex
       } as PluginConfig;
 
-      expect(getTickets(config, context)).toEqual(['FIX-321', 'UH-1258', 'FIX-123', 'TEST-123'])
+      expect(getTickets(config, context)).toEqual(['FIX-321', 'UH-1258', 'FIX-123', 'TEST-123', 'TEST-234'])
     })
   })
 })


### PR DESCRIPTION
<!--
## Pull Request template
-->
### Description
Allow multiple tickets in the same commit message

Exemple on commit message:
`fix: [TEST-123] [TEST-234] test commit`
<!-- enter a description of your change here -->

### This is a 
<!-- Pick One -->
- [ ] Bug Fix
- [x] Feature
- [ ] Documentation
- [ ] Other

## Checklists
#### Commit style
   <!-- Check all the following -->
   - [x] Changes are on a branch with a descriptive name eg. `fix/missing-queue`, `docs/setup-guide`
   
   - [x] Commits start with one of `feat:` `fix:` `docs:` `chore:` or similar
   
   - [x] No excessive commits, eg: there should be no `fix:` commits for bugs that existed only on the PR branch (see [guide-to-interactive-rebasing](https://hackernoon.com/beginners-guide-to-interactive-rebasing-346a3f9c3a6d))

#### Protected files

The following files should not change unless they are directly a part of your change.
    <!-- Check any of the bellow files that have changed, add a reason for each if nessesary  -->
   - [ ] `yarn.lock` (unless package.json is also modified, then only the new/updated package should be changed here)
   
   - [ ] `package.json` (renovate bot should handle all routine updates)
   
   - [ ] `tsconfig.json` (only make it stricter, making it more lenient requires more discussion)
   
   - [ ] `tslint.json` (only make it stricter, making it more lenient requires more discussion)
