### PR TITLE
fix: throw readable error if connecting to JIRA fails during verifyCo…

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,6 +1,13 @@
 module.exports = {
   presets: [
-    '@babel/preset-env',
+    [
+      '@babel/preset-env',
+      {
+        targets: {
+          node: 'current'
+        }
+      }
+    ],
     '@babel/preset-typescript',
   ],
 };

--- a/lib/verifyConditions.ts
+++ b/lib/verifyConditions.ts
@@ -56,5 +56,13 @@ export async function verifyConditions(config: PluginConfig, context: PluginCont
     throw new SemanticReleaseError(`JIRA_AUTH must be a string`);
   }
   const jira = makeClient(config, context);
-  await jira.project.getProject({ projectIdOrKey: config.projectId });
+  try {
+    await jira.project.getProject({ projectIdOrKey: config.projectId });
+  } catch (e) {
+    if (typeof e === 'string' && e.includes('"statusCode"')) {
+      throw new SemanticReleaseError(`connecting to jira failed with status ${JSON.parse(e).statusCode}`);
+    } else {
+      throw new SemanticReleaseError(`connecting to jira failed`, '', e);
+    }
+  }
 }

--- a/test/fakedata.ts
+++ b/test/fakedata.ts
@@ -50,10 +50,11 @@ export const upcomingRelease: UpcomingRelease = {
   type: ''
 }
 
-export const pluginConfig: Partial<PluginConfig> = {
+export const pluginConfig: PluginConfig = {
   ...baseConfig,
   projectId: 'TEST',
-  jiraHost: 'testjira.com'
+  jiraHost: 'testjira.com',
+  ticketPrefixes: ['TEST'],
 }
 
 export const logger = {
@@ -62,7 +63,9 @@ export const logger = {
 
 export const pluginContext: PluginContext = {
   cwd: '',
-  env: {},
+  env: {
+    JIRA_AUTH: 'myauth'
+  },
   logger: logger as any,
   options: baseConfig,
   stderr: null,

--- a/test/verifyConditions.test.ts
+++ b/test/verifyConditions.test.ts
@@ -1,0 +1,34 @@
+import { pluginConfig, pluginContext } from './fakedata';
+
+function throwOnJiraGetProject(mockError: string | Error): void {
+  jest.mock('jira-connector', () => ({
+    __esModule: true,
+    default: jest.fn().mockImplementation(() => ({
+      project: {
+        getProject: () => {
+          throw mockError;
+        },
+      },
+    })),
+  }));
+}
+
+describe('verifyConditions', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  describe('JIRA connection check', () => {
+    it('catches status errors', () => {
+      throwOnJiraGetProject('{"statusCode": 401, "response": ""}');
+      const verifyConditions = require('../lib/verifyConditions').verifyConditions;
+      expect(() => verifyConditions(pluginConfig, pluginContext)).rejects.toThrow('connecting to jira failed with status 401');
+    });
+
+    it('catches other errors', () => {
+      throwOnJiraGetProject(new Error('foobar'));
+      const verifyConditions = require('../lib/verifyConditions').verifyConditions;
+      expect(() => verifyConditions(pluginConfig, pluginContext)).rejects.toThrow('connecting to jira failed');
+    });
+  });
+});


### PR DESCRIPTION
<!--
## Pull Request template
-->
### Description
fix #72 by throwing readable errors when connecting to JIRA fails.

### This is a 
<!-- Pick One -->
- [x] Bug Fix
- [ ] Feature
- [ ] Documentation
- [ ] Other

## Checklists
#### Commit style
   <!-- Check all the following -->
   - [x] Changes are on a branch with a descriptive name eg. `fix/missing-queue`, `docs/setup-guide`
   
   - [x] Commits start with one of `feat:` `fix:` `docs:` `chore:` or similar
   
   - [x] No excessive commits, eg: there should be no `fix:` commits for bugs that existed only on the PR branch (see [guide-to-interactive-rebasing](https://hackernoon.com/beginners-guide-to-interactive-rebasing-346a3f9c3a6d))

#### Protected files

The following files should not change unless they are directly a part of your change.
    <!-- Check any of the bellow files that have changed, add a reason for each if nessesary  -->
   - [x] `yarn.lock` (unless package.json is also modified, then only the new/updated package should be changed here)
   
   - [x] `package.json` (renovate bot should handle all routine updates)
   
   - [x] `tsconfig.json` (only make it stricter, making it more lenient requires more discussion)
   
   - [x] `tslint.json` (only make it stricter, making it more lenient requires more discussion)

